### PR TITLE
don't use the develop branch

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -189,7 +189,7 @@ resources:
   type: git
   source:
     uri: https://github.com/concourse/concourse-bosh-deployment
-    branch: develop
+    branch: master
     tag_filter: v6.*
 
 - name: concourse-config


### PR DESCRIPTION
## Changes proposed in this pull request:

The current pipeline uses the develop branch in the upstream repo. It appears this has been the case since 2018 and we are not sure why. The upstream deleted the branch.


## security considerations

none
