### PR TITLE
enable global resource fetching

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -22,6 +22,7 @@ jobs:
       - concourse-deployment/cluster/operations/build-log-retention.yml
       - concourse-deployment/cluster/operations/scale.yml
       - concourse-deployment/cluster/operations/debug-concourse.yml
+      - concourse-deployment/cluster/operations/enable-global-resources.yml
       - concourse-config/operations/iaas-worker.yml
       - concourse-config/operations/postgres-staging.yml
       - concourse-config/operations/driver.yml
@@ -133,6 +134,7 @@ jobs:
       - concourse-deployment/cluster/operations/build-log-retention.yml
       - concourse-deployment/cluster/operations/scale.yml
       - concourse-deployment/cluster/operations/debug-concourse.yml
+      - concourse-deployment/cluster/operations/enable-global-resources.yml
       - concourse-config/operations/iaas-worker.yml
       - concourse-config/operations/postgres-production.yml
       - concourse-config/operations/external-postgres-tls.yml


### PR DESCRIPTION
## Changes proposed in this pull request:

Enables global resource fetching: https://concourse-ci.org/global-resources.html

## security considerations

None. The same content is fetched regardless of this setting. This is simply more efficient.
