### PR TITLE
Registry mirror

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -249,6 +249,8 @@ resource_types:
     repository: cloudfoundry/bosh-deployment-resource
 
 - name: s3-iam
-  type: docker-image
+  type: registry-image
   source:
     repository: 18fgsa/s3-resource
+    registry_mirror:
+      host: docker-registry-mirror.app.cloud.gov:443

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -32,7 +32,6 @@ jobs:
       - concourse-config/operations/prometheus.yml
       - concourse-config/operations/update-strategy.yml
       - concourse-config/operations/set-garbage-collection.yml
-      - concourse-config/operations/garden-ini.yml
       # - concourse-config/operations/staging-disk-size.yml
       vars_files:
       - concourse-deployment/versions.yml
@@ -143,7 +142,6 @@ jobs:
       - concourse-config/operations/prometheus.yml
       - concourse-config/operations/update-strategy.yml
       - concourse-config/operations/set-garbage-collection.yml
-      - concourse-config/operations/garden-ini.yml
       # - concourse-config/operations/production-disk-size.yml
       vars_files:
       - concourse-deployment/versions.yml
@@ -239,14 +237,18 @@ resources:
 
 resource_types:
 - name: slack-notification-docker
-  type: docker-image
+  type: registry-image
   source:
     repository: cfcommunity/slack-notification-resource
+    registry_mirror:
+      host: docker-registry-mirror.app.cloud.gov:443
 
 - name: bosh-deployment
-  type: docker-image
+  type: regsitry-image
   source:
     repository: cloudfoundry/bosh-deployment-resource
+    registry_mirror:
+      host: docker-registry-mirror.app.cloud.gov:443
 
 - name: s3-iam
   type: registry-image

--- a/ci/smoke-test.yml
+++ b/ci/smoke-test.yml
@@ -1,9 +1,11 @@
 ---
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: 18fgsa/concourse-task
+    registry_mirror:
+      host: docker-registry-mirror.app.cloud.gov:443
 
 inputs:
 - name: concourse-config


### PR DESCRIPTION
## Changes proposed in this pull request:

Changes docker-image resources to registry-image and sets the registry mirror. This is an attempt to be able to upgrade concourse while docker hub pull limits are in place.

## security considerations

None
