### PR TITLE
use registry mirror for jumpboxes

### DIFF
--- a/jumpbox.yml
+++ b/jumpbox.yml
@@ -1,9 +1,11 @@
 ---
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: 18fgsa/concourse-task
+    registry_mirror:
+      host: docker-registry-mirror.app.cloud.gov:443
 
 inputs:
 - name: concourse-config


### PR DESCRIPTION
## Changes proposed in this pull request:

Temporary fix to allow jumpboxes to be created via our mirror due to docker hub pull limits

## security considerations

None
