### PR TITLE
set registry-image and docker-image resources to use docker hub mirror

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -33,6 +33,7 @@ jobs:
       - concourse-config/operations/prometheus.yml
       - concourse-config/operations/update-strategy.yml
       - concourse-config/operations/set-garbage-collection.yml
+      - concourse-config/operations/base-resource-defaults.yml
       # - concourse-config/operations/staging-disk-size.yml
       vars_files:
       - concourse-deployment/versions.yml
@@ -144,6 +145,7 @@ jobs:
       - concourse-config/operations/prometheus.yml
       - concourse-config/operations/update-strategy.yml
       - concourse-config/operations/set-garbage-collection.yml
+      - concourse-config/operations/base-resource-defaults.yml
       # - concourse-config/operations/production-disk-size.yml
       vars_files:
       - concourse-deployment/versions.yml

--- a/operations/base-resource-defaults.yml
+++ b/operations/base-resource-defaults.yml
@@ -1,0 +1,8 @@
+- type: replace
+  path: /instance_groups/name=web/jobs/name=web/properties/base_resource_type_defaults?
+  value: >
+    registry-image:
+      registry_mirror:
+        host: ((docker-registry-mirror))
+    docker-image:
+      registry_mirror: ((docker-registry-mirror))


### PR DESCRIPTION
## Changes proposed in this pull request:

Globally configures the registry-image and docker-image resources to use our docker hub mirror. Property setting documentation is here: https://bosh.io/jobs/web?source=github.com/concourse/concourse-bosh-release&version=6.7.1#p%3dbase_resource_type_defaults

The source configs for the type resource types differ slightly:
- registry-image: https://github.com/concourse/registry-image-resource#source-configuration
- docker-image: https://github.com/concourse/docker-image-resource#source-configuration


NOTE: the existing registry_mirror settings in the resource_type section will be removed after the update is completed. They need to be here to roll out the update.

## security considerations

None. The mirror is a pull-through cache only. No one can push to our mirror.
