### PR TITLE
add concourse pages scope

### DIFF
--- a/operations/generic-oauth.yml
+++ b/operations/generic-oauth.yml
@@ -4,7 +4,7 @@
     auth_url: https://opslogin.fr.cloud.gov/oauth/authorize
     token_url: https://opsuaa.fr.cloud.gov/oauth/token
     userinfo_url: https://opsuaa.fr.cloud.gov/userinfo
-    scopes: [openid, concourse.admin]
+    scopes: [openid, concourse.admin, concourse.pages]
     groups_key: scope
     client_id: ((generic_oauth_client_id))
     client_secret: ((generic_oauth_client_secret))


### PR DESCRIPTION
## Changes proposed in this pull request:

Add the `concourse.pages` scope to the oauth provider scope. Without this, the scope will never be valid in concourse's eyes.

## security considerations

Omitting this proves the scope security works. This is necessary for concourse.pages users to see the team.
