### PR TITLE
Use new default branch

### DIFF
--- a/ci/concourse-defaults.yml
+++ b/ci/concourse-defaults.yml
@@ -1,4 +1,4 @@
-concourse-config-git-branch: master
+concourse-config-git-branch: main
 concourse-config-git-url: https://github.com/18F/cg-deploy-concourse.git
 
 pipeline-tasks-git-branch: master


### PR DESCRIPTION
## Changes proposed in this pull request:
- This repo's default branch is now `main`; update the resource accordingly.

## security considerations
None, just a branch rename.