### PR TITLE
Adding in ops file to override hardcoding from concourse-deployment

### DIFF
--- a/operations/use-bionic.yml
+++ b/operations/use-bionic.yml
@@ -1,0 +1,24 @@
+# Remove the old 6.x Concourse deployment stemcell value - this can be pulled once we get current with Concourse
+- type: remove
+  path: /stemcells/alias=xenial?
+
+# Add in a stemcell defination for default
+- type: replace
+  path: /stemcells/-
+  value:
+    alias: default
+    os: ubuntu-bionic
+    version: latest
+
+# Set instance names to use default stemcell
+- type: replace
+  path: /instance_groups/name=web/stemcell
+  value: default
+
+- type: replace
+  path: /instance_groups/name=worker/stemcell
+  value: default
+
+- type: replace
+  path: /instance_groups/name=iaas-worker/stemcell
+  value: default


### PR DESCRIPTION
## Changes proposed in this pull request:
- Force use of bionic stemcell via ops file to over ride 6.x tag concourse-deployment file from public repo

## security considerations
n/a
