### PR TITLE
adding bosh-dns alias so prometheus can query concourse for metrics

### DIFF
--- a/operations/bosh-dns-aliases.yml
+++ b/operations/bosh-dns-aliases.yml
@@ -13,6 +13,7 @@
           network: opsuaa
           query: '*'
 
+
 - type: replace
   path: /instance_groups/name=web/jobs/-
   value:
@@ -27,6 +28,13 @@
           instance_group: opsuaa
           network: opsuaa
           query: '*'
+      - domain: ((deployment_name)).service.monitoring
+        targets:
+        - query: '*'
+          instance_group: web
+          deployment: ((deployment_name))
+          network: ((network_name))
+          domain: bosh
         
 - type: replace
   path: /releases/-


### PR DESCRIPTION
## Changes proposed in this pull request:
- should add environment specific bosh-dns names so we can then query the metrics from the same environment prometheus

## security considerations
n/a
