### PR TITLE
Fix concourse domain name per #167

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 18F Concourse deployment
 
-This repo contains the pipeline and [BOSH](https://bosh.io) manifests for deploying [Concourse](https://concourse.ci/) tasks.
+This repo contains the pipeline and [BOSH](https://bosh.io) manifests for deploying [Concourse](https://concourse-ci.org/) tasks.
 
 ## Generating certificates
 


### PR DESCRIPTION
## Changes proposed in this pull request:
-
- Fix concourse domain name per #167
-

## security considerations
Let's not link to the wrong domain per https://tanzu.vmware.com/security/cve-2018-1227
