### PR TITLE
use cloud-gov org name

### DIFF
--- a/shell-pipeline-pages.yml
+++ b/shell-pipeline-pages.yml
@@ -35,7 +35,7 @@ resources:
 - name: cg-scripts
   type: git
   source:
-    uri: https://github.com/18F/cg-scripts
+    uri: https://github.com/cloud-gov/cg-scripts
     branch: master
 
 resource_types:

--- a/shell-pipeline.yml
+++ b/shell-pipeline.yml
@@ -108,7 +108,7 @@ resources:
 - name: cg-scripts
   type: git
   source:
-    uri: https://github.com/18F/cg-scripts
+    uri: https://github.com/cloud-gov/cg-scripts
     branch: master
 
 resource_types:


### PR DESCRIPTION
## Changes proposed in this pull request:
- use cloud-gov org name


## security considerations
None