### PR TITLE
Increasing max containers for workers

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -34,6 +34,7 @@ jobs:
       - concourse-config/operations/update-strategy.yml
       - concourse-config/operations/set-garbage-collection.yml
       - concourse-config/operations/base-resource-defaults.yml
+      - concourse-config/operations/max-containers.yml
       - concourse-config/operations/bosh-dns-aliases.yml
       - concourse-config/operations/enable-across-step.yml
       vars_files:
@@ -162,6 +163,7 @@ jobs:
       - concourse-config/operations/update-strategy.yml
       - concourse-config/operations/set-garbage-collection.yml
       - concourse-config/operations/base-resource-defaults.yml
+      - concourse-config/operations/max-containers.yml
       - concourse-config/operations/bosh-dns-aliases.yml
       - concourse-config/operations/enable-across-step.yml
       vars_files:

--- a/operations/max-containers.yml
+++ b/operations/max-containers.yml
@@ -1,0 +1,3 @@
+- type: replace
+  path: /instance_groups/name=worker/jobs/name=worker/properties/garden/max_containers?
+  value: 500


### PR DESCRIPTION
## Changes proposed in this pull request:
- Increases max containers from 250 to 500. Network can handle 16K potentional containers now. https://github.com/concourse/concourse-bosh-release/blob/master/jobs/worker/spec#L238-L241
- Worker VMs dont have high load and old limit was because the network was limited to 256 before but not anymore

## security considerations
This increases security since it makes concourse better