### PR TITLE
add jumpbox with iaas tags for managing bosh releases

### DIFF
--- a/shell-pipeline.yml
+++ b/shell-pipeline.yml
@@ -105,6 +105,25 @@ jobs:
       CREDHUB_SERVER: ((production-standalone-credhub.api-server))
       PROMPT_COLOR: "1" # red
 
+
+- name: container-bosh-release-development
+  plan:
+  - in_parallel: *resources
+  - task: jumpbox
+    file: concourse-config/jumpbox.yml
+    tags: [iaas]
+    params:
+      BOSH_DIRECTOR_NAME: development
+      BOSH_ENVIRONMENT: ((development-bosh.target))
+      BOSH_CLIENT: ((development-bosh.uaa-client))
+      BOSH_CLIENT_SECRET: ((development-bosh.uaa-secret))
+      BOSH_CA_CERT: master-bosh-root-cert/master-bosh.crt
+      CREDHUB_CA_CERT: master-bosh-root-cert/master-bosh.crt
+      CREDHUB_CLIENT: ((development-credhub.admin-client))
+      CREDHUB_SECRET: ((development-credhub.admin-secret))
+      CREDHUB_SERVER: ((development-credhub.api-server))
+      PROMPT_COLOR: "6" # cyan
+
 resources:
 - name: concourse-config
   type: git


### PR DESCRIPTION
## Changes proposed in this pull request:

- add jumpbox with iaas tags for managing bosh releases

## security considerations

The `iaas` tag on this jumpbox ensures thethat build container is launched on a particular worker node, in this case the IAAS worker VM which has the ECInstanceProfile to perform infrastructure work, including IAM permissions to read objects from S3, etc. These IAM permissions are already present on that VM, this PR is just creating a jumpbox container where they can be leveraged from the `aws` CLI to facilitate the BOSH release testing process. 

This jumpbox is also only being provisioned for the BOSH development environment, not staging or production.