### PR TITLE
add opsfile to manage container placement strategy

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -37,6 +37,7 @@ jobs:
       - concourse-config/operations/max-containers.yml
       - concourse-config/operations/bosh-dns-aliases.yml
       - concourse-config/operations/enable-across-step.yml
+      - concourse-config/operations/container-placement.yml
       vars_files:
       - concourse-deployment/versions.yml
       - concourse-config/variables/staging.yml
@@ -180,6 +181,7 @@ jobs:
       - concourse-config/operations/max-containers.yml
       - concourse-config/operations/bosh-dns-aliases.yml
       - concourse-config/operations/enable-across-step.yml
+      - concourse-config/operations/container-placement.yml
       vars_files:
       - concourse-deployment/versions.yml
       - concourse-config/variables/production.yml

--- a/operations/container-placement.yml
+++ b/operations/container-placement.yml
@@ -1,6 +1,6 @@
 - type: replace
-  path: /instance_groups/name=web/jobs/name=web/properties/container_placement_strategy?
-  value: limit-active-containers,volume-locality,fewest-build-containers
+  path: /instance_groups/name=web/jobs/name=web/properties/container_placement_strategies?
+  value: [limit-active-containers,volume-locality,fewest-build-containers]
 
 - type: replace
   path: /instance_groups/name=web/jobs/name=web/properties/max_active_containers_per_worker?

--- a/operations/container-placement.yml
+++ b/operations/container-placement.yml
@@ -1,0 +1,7 @@
+- type: replace
+  path: /instance_groups/name=web/jobs/name=web/properties/container_placement_strategy?
+  value: limit-active-containers,volume-locality,fewest-build-containers
+
+- type: replace
+  path: /instance_groups/name=web/jobs/name=web/properties/max_active_containers_per_worker?
+  value: 200

--- a/operations/container-placement.yml
+++ b/operations/container-placement.yml
@@ -4,4 +4,4 @@
 
 - type: replace
   path: /instance_groups/name=web/jobs/name=web/properties/max_active_containers_per_worker?
-  value: 200
+  value: ((max_active_containers_per_worker))

--- a/variables/development.yml
+++ b/variables/development.yml
@@ -13,3 +13,4 @@ worker_instances: 2
 iaas_worker_instances: 1
 build_logs_default: 25
 build_logs_maximum: 0
+max_active_containers_per_worker: 50

--- a/variables/production.yml
+++ b/variables/production.yml
@@ -9,7 +9,7 @@ worker_vm_extensions: [production-concourse-profile]
 iaas_worker_vm_extensions: [production-concourse-iaas-profile]
 network_name: production-concourse
 web_instances: 4
-worker_instances: 9
+worker_instances: 10
 iaas_worker_instances: 2
 build_logs_default: 25
 build_logs_maximum: 0

--- a/variables/production.yml
+++ b/variables/production.yml
@@ -13,3 +13,4 @@ worker_instances: 10
 iaas_worker_instances: 2
 build_logs_default: 25
 build_logs_maximum: 0
+max_active_containers_per_worker: 200

--- a/variables/staging.yml
+++ b/variables/staging.yml
@@ -14,3 +14,4 @@ worker_instances: 2
 iaas_worker_instances: 1
 build_logs_default: 25
 build_logs_maximum: 0
+max_active_containers_per_worker: 100


### PR DESCRIPTION
## Changes proposed in this pull request:

We are having an issue where our worker VMs seem to be filling up rapidly with containers causing Concourse outages.

We still need to identify what is causing the proliferation of so many workers, but in the meantime, it seems like we should update our [container placement strategy](https://concourse-ci.org/container-placement.html).

The default strategy, `volume-locality`, makes no attempt to determine how many containers are running on a VM before placing containers. So it could be contributing to the issue of VMs quickly filling up with too many containers.

These changes update our container placement strategy to:

- `limit-active-containers` - Limit active containers per VM to 200
- `volume-locality` - Try to group containers onto VMs using the same inputs
- `fewest-build-containers` - Filter the possible list of containers by the one with the fewest containers

These strategies are used as chained filters, so the output from each strategy limits the number of containers passed in as options to the next strategy.

## security considerations

None
