### PR TITLE
Make prod deployment be manual for changes to the version of concourse deployment

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -151,7 +151,6 @@ jobs:
   - in_parallel:
     - get: concourse-deployment
       passed: [deploy-concourse-staging]
-      trigger: true
     - get: concourse-config
       passed: [deploy-concourse-staging]
       trigger: true

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -38,7 +38,6 @@ jobs:
       - concourse-config/operations/bosh-dns-aliases.yml
       - concourse-config/operations/enable-across-step.yml
       - concourse-config/operations/container-placement.yml
-      - concourse-config/operations/use-jammy.yml
       vars_files:
       - concourse-deployment/versions.yml
       - concourse-config/variables/staging.yml
@@ -182,7 +181,6 @@ jobs:
       - concourse-config/operations/bosh-dns-aliases.yml
       - concourse-config/operations/enable-across-step.yml
       - concourse-config/operations/container-placement.yml
-      - concourse-config/operations/use-jammy.yml
       vars_files:
       - concourse-deployment/versions.yml
       - concourse-config/variables/production.yml


### PR DESCRIPTION
## Changes proposed in this pull request:
- Make prod deployment be manual for changes to the version of concourse deployment, want to make sure that we have some time in staging (like cf and logsearch) before letting it rip in production
-
-

## security considerations
None
