### PR TITLE
Adding Support For Viewer role

### DIFF
--- a/operations/generic-oauth.yml
+++ b/operations/generic-oauth.yml
@@ -4,7 +4,7 @@
     auth_url: https://opslogin.fr.cloud.gov/oauth/authorize
     token_url: https://opsuaa.fr.cloud.gov/oauth/token
     userinfo_url: https://opsuaa.fr.cloud.gov/userinfo
-    scopes: [openid, concourse.admin, concourse.pages]
+    scopes: [openid, concourse.admin, concourse.pages, concourse.viewer]
     groups_key: scope
     client_id: ((generic_oauth_client_id))
     client_secret: ((generic_oauth_client_secret))

--- a/teams/teams.tf
+++ b/teams/teams.tf
@@ -15,21 +15,27 @@ provider "concourse" {
   password = var.concourse_password
 }
 
+resource "concourse_team" "main" {
+  team_name = "main"
+
+  owners = [
+    "group:oauth:concourse.admin",
+    "local:users:"admin""
+  ]
+
+  viewer = [
+    "group:oauth:concourse.viewer"
+  ]
+}
+
 resource "concourse_team" "pages" {
   team_name = "pages"
 
   members = [
     "group:oauth:concourse.pages"
   ]
-
-}
-
-resource "concourse_team" "support" {
-  team_name = "support"
-
   viewer = [
     "group:oauth:concourse.viewer"
   ]
 
 }
-

--- a/teams/teams.tf
+++ b/teams/teams.tf
@@ -23,3 +23,13 @@ resource "concourse_team" "pages" {
   ]
 
 }
+
+resource "concourse_team" "support" {
+  team_name = "support"
+
+  viewer = [
+    "group:oauth:concourse.viewer"
+  ]
+
+}
+

--- a/teams/teams.tf
+++ b/teams/teams.tf
@@ -20,7 +20,7 @@ resource "concourse_team" "main" {
 
   owners = [
     "group:oauth:concourse.admin",
-    "local:users:"admin""
+    "local:users:admin"
   ]
 
   viewer = [


### PR DESCRIPTION
## Changes proposed in this pull request:
- Setting up Concourse to support read-only mode for support and contract work

## security considerations
Viewer role allows read only access to Concourse - Support members can not make changes nor launch new jobs
