### PR TITLE
No longer make prod auto-fire

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -152,10 +152,8 @@ jobs:
       passed: [deploy-concourse-staging]
     - get: concourse-config
       passed: [deploy-concourse-staging]
-      trigger: true
     - get: terraform-yaml
     - get: concourse-stemcell-jammy
-      trigger: true
       passed: [deploy-concourse-staging]
   - put: concourse-production-deployment
     params:


### PR DESCRIPTION
## Changes proposed in this pull request:
- Remove auto trigger of concourse production.  This will allow the maintenance person to run the stemcell and other upgrades during off-peak hours to limit impact to the operators
-
-

## security considerations
None
