### PR TITLE
Switch web vms in prod to m5.large

### DIFF
--- a/variables/production.yml
+++ b/variables/production.yml
@@ -1,7 +1,7 @@
 deployment_name: concourse-production
 external_url: https://ci.fr.cloud.gov
 azs: [z1]
-web_vm_type: t3.medium.concourse.web
+web_vm_type: m5.large.concourse.web
 worker_vm_type: m5.xlarge.concourse.worker
 iaas_worker_vm_type: m5.xlarge.concourse.worker
 web_vm_extensions: [production-concourse-lb]


### PR DESCRIPTION
## Changes proposed in this pull request:
- Switch the production web nodes to use the `m5.large.concourse.web` instance type added to the cloud config with https://github.com/cloud-gov/cg-deploy-bosh/pull/580
- Web nodes show high swap usage in metrics dashboards
- Need to wait for the cloud config changes to flush before merging

## security considerations
None
