### PR TITLE
Move iptables to prestart script

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -334,10 +334,6 @@ resources:
       access_key: ((aws_s3_access_key_id))
       secret_key: ((aws_s3_secret_access_key))
 
-- name: hourly-timer
-  type: time
-  source:
-    interval: 1h
 
 resource_types:
 - name: slack-notification

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -38,6 +38,7 @@ jobs:
       - concourse-config/operations/bosh-dns-aliases.yml
       - concourse-config/operations/enable-across-step.yml
       - concourse-config/operations/container-placement.yml
+      - concourse-config/operations/iptables.yml
       vars_files:
       - concourse-deployment/versions.yml
       - concourse-config/variables/staging.yml
@@ -72,13 +73,6 @@ jobs:
   serial: true
   interruptible: true
   plan:
-  - in_parallel:  
-    - get: concourse-staging-deployment
-      passed:
-      - deploy-concourse-staging
-      trigger: true
-    - get: hourly-timer
-      trigger: true
   - task: iptables-iaas-worker-bosh-dns
     config: &iptables-iaas-worker-bosh-dns
       container_limits: {}
@@ -188,6 +182,7 @@ jobs:
       - concourse-config/operations/bosh-dns-aliases.yml
       - concourse-config/operations/enable-across-step.yml
       - concourse-config/operations/container-placement.yml
+      - concourse-config/operations/iptables.yml
       vars_files:
       - concourse-deployment/versions.yml
       - concourse-config/variables/production.yml
@@ -224,13 +219,6 @@ jobs:
   serial: true
   interruptible: true
   plan:
-  - in_parallel:
-    - get: concourse-production-deployment
-      passed:
-      - deploy-concourse-production
-      trigger: true
-    - get: hourly-timer
-      trigger: true
   - task: iptables-iaas-worker-bosh-dns
     config:
       <<: *iptables-iaas-worker-bosh-dns

--- a/operations/iptables.yml
+++ b/operations/iptables.yml
@@ -1,0 +1,35 @@
+- type: replace
+  path: /instance_groups/name=worker/jobs/-
+  value: 
+    name: pre-start-script
+    release: os-conf
+    properties:
+      script: |
+        #!/bin/bash
+        iptables-legacy -D INPUT -s 10.80.0.0/16 -d 169.254.0.2/32 -p udp -m udp --dport 53 -j ACCEPT
+        iptables-legacy -D INPUT -s 10.80.0.0/16 -d 169.254.0.2/32 -p tcp -m tcp --dport 53 -j ACCEPT
+        iptables-legacy -I INPUT 1 -s 10.80.0.0/16 -d 169.254.0.2/32 -p udp -m udp --dport 53 -j ACCEPT
+        iptables-legacy -I INPUT 1 -s 10.80.0.0/16 -d 169.254.0.2/32 -p tcp -m tcp --dport 53 -j ACCEPT
+        /bin/true
+
+
+- type: replace
+  path: /instance_groups/name=iaas-worker/jobs/-
+  value: 
+    name: pre-start-script
+    release: os-conf
+    properties:
+      script: |
+        #!/bin/bash
+        iptables-legacy -D INPUT -s 10.80.0.0/16 -d 169.254.0.2/32 -p udp -m udp --dport 53 -j ACCEPT
+        iptables-legacy -D INPUT -s 10.80.0.0/16 -d 169.254.0.2/32 -p tcp -m tcp --dport 53 -j ACCEPT
+        iptables-legacy -I INPUT 1 -s 10.80.0.0/16 -d 169.254.0.2/32 -p udp -m udp --dport 53 -j ACCEPT
+        iptables-legacy -I INPUT 1 -s 10.80.0.0/16 -d 169.254.0.2/32 -p tcp -m tcp --dport 53 -j ACCEPT
+        /bin/true
+
+
+- type: replace
+  path: /releases/-
+  value:
+    name: os-conf  
+    version: latest


### PR DESCRIPTION
## Changes proposed in this pull request:
- Moves iptables commands to be a prestart script on the worker nodes
- No longer dependent on an external concourse task to set these
- Part of https://github.com/cloud-gov/product/issues/2930

## security considerations
None
