### PR TITLE
Removing lidar polling config param

### DIFF
--- a/operations/config.yml
+++ b/operations/config.yml
@@ -34,6 +34,3 @@
   path: /instance_groups/name=web/jobs/name=web/properties/default_check_interval_with_webhook?
   value: 3m
 
-- type: replace
-  path: /instance_groups/name=web/jobs/name=web/properties/lidar_scanner_interval?
-  value: 10m


### PR DESCRIPTION
## Changes proposed in this pull request:
- Removing the `lidar_scanner_interval` property - it was a blocker for specific use cases and not offering any platform wide benefit - this was a primary Pages usage blocker
- By removing `lidar_scanner_interval` but keeping `default_check_interval*` resources in the config - we set default intervals for resource checks but allow specific resources to increase their interval using `check_every` in their resource definitions 

## security considerations
n/a
