### PR TITLE
replace harden-concourse-task

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -82,9 +82,9 @@ jobs:
         source:
           aws_access_key_id: ((ecr_aws_key))
           aws_secret_access_key: ((ecr_aws_secret))
-          repository: harden-concourse-task
+          repository: general-task
           aws_region: us-gov-west-1
-          tag: ((harden-concourse-task-tag))
+          tag: latest
       params:
         BOSH_ENVIRONMENT: ((concourse-staging-deployment-bosh-target))
         BOSH_CLIENT: ci
@@ -112,9 +112,9 @@ jobs:
         source:
           aws_access_key_id: ((ecr_aws_key))
           aws_secret_access_key: ((ecr_aws_secret))
-          repository: harden-concourse-task
+          repository: general-task
           aws_region: us-gov-west-1
-          tag: ((harden-concourse-task-tag))
+          tag: latest
       params:
         BOSH_ENVIRONMENT: ((concourse-staging-deployment-bosh-target))
         BOSH_CLIENT: ci


### PR DESCRIPTION
## Changes proposed in this pull request:
- Use general-task instead of harden-concourse-task

## security considerations
Use latest hardened image
