### PR TITLE
add meta-data-v2 vm_extension for worker VMs

### DIFF
--- a/variables/development.yml
+++ b/variables/development.yml
@@ -5,8 +5,8 @@ web_vm_type: production-concourse-web
 worker_vm_type: production-concourse-worker
 iaas_worker_vm_type: production-concourse-iaas-worker
 web_vm_extensions: [production-concourse-lb]
-worker_vm_extensions: [production-concourse-profile]
-iaas_worker_vm_extensions: [production-concourse-iaas-profile]
+worker_vm_extensions: [production-concourse-profile, meta-data-v2]
+iaas_worker_vm_extensions: [production-concourse-iaas-profile, meta-data-v2]
 network_name: production-concourse
 web_instances: 1
 worker_instances: 2

--- a/variables/production.yml
+++ b/variables/production.yml
@@ -5,8 +5,8 @@ web_vm_type: m6i.large.concourse.web
 worker_vm_type: m6i.xlarge.concourse.worker
 iaas_worker_vm_type: m6i.xlarge.concourse.worker
 web_vm_extensions: [production-concourse-lb]
-worker_vm_extensions: [production-concourse-profile]
-iaas_worker_vm_extensions: [production-concourse-iaas-profile]
+worker_vm_extensions: [production-concourse-profile, meta-data-v2]
+iaas_worker_vm_extensions: [production-concourse-iaas-profile, meta-data-v2]
 network_name: production-concourse
 web_instances: 2
 worker_instances: 10

--- a/variables/staging.yml
+++ b/variables/staging.yml
@@ -6,8 +6,8 @@ web_vm_type: t3.medium.concourse.web
 worker_vm_type: m5.xlarge.concourse.worker
 iaas_worker_vm_type: m5.xlarge.concourse.worker
 web_vm_extensions: [staging-concourse-lb]
-worker_vm_extensions: [staging-concourse-profile]
-iaas_worker_vm_extensions: [staging-concourse-iaas-profile]
+worker_vm_extensions: [staging-concourse-profile, meta-data-v2]
+iaas_worker_vm_extensions: [staging-concourse-iaas-profile, meta-data-v2]
 network_name: staging-concourse
 web_instances: 1
 worker_instances: 2


### PR DESCRIPTION
## Changes proposed in this pull request:

[Add the `meta-data-v2` `vm_extension`](https://github.com/cloud-gov/cg-deploy-bosh/blob/main/cloud-config/base.yml#L514-L518) to the worker and iaas-worker VMs.

Notably, the `meta-data-v2` VM extension sets `http_put_response_hop_limit: 2`, [which is officially recommended by when using containers on a VM](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html):

> **In a container environment, set the hop limit to 2**
> The AWS SDKs use IMDSv2 calls by default. If the IMDSv2 call receives no response, the SDK retries the call and, if still unsuccessful, uses IMDSv1. This can result in a delay, especially in a container environment. In a container environment, if the hop limit is 1, the IMDSv2 response does not return because going to the container is considered an additional network hop. To avoid the process of falling back to IMDSv1 and the resultant delay, in a container environment we recommend that you set the hop limit to 2. For more information, see [Configure the Instance Metadata Service options](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-options.html).

We currently have `http_put_response_hop_limit: 1` on the Concourse worker VMs and we think that it may be the source of slowness with BOSH downloading blobs from S3. This issue gives us a clue that `http_put_response_hop_limit: 1` can cause general slowness when running containers on VMs: https://github.com/aws/aws-sdk-go/issues/2972

## security considerations

The `meta-data-v2` VM extension also sets `http_tokens: required` [which requires the use of the Instance Metadata Service v2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html#instance-metadata-v2-how-it-works)
