### PR TITLE
Ensure pipeline does not run when BOSH is deploying using lock

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1,331 +1,331 @@
 ---
 jobs:
-- name: deploy-concourse-staging
-  serial: true
-  interruptible: true
-  plan:
-  - in_parallel:
-    - get: concourse-deployment
-      trigger: true
-    - get: concourse-config
-      trigger: true
-    - get: terraform-yaml
-    - get: concourse-stemcell-jammy
-      trigger: true
-  - put: concourse-staging-deployment
-    params: &deploy-params
-      manifest: concourse-deployment/cluster/concourse.yml
-      stemcells:
-      - concourse-stemcell-jammy/*.tgz
-      ops_files:
-      - concourse-deployment/cluster/operations/basic-auth.yml
-      - concourse-deployment/cluster/operations/build-log-retention.yml
-      - concourse-deployment/cluster/operations/scale.yml
-      - concourse-deployment/cluster/operations/enable-global-resources.yml
-      - concourse-config/operations/credhub.yml
-      - concourse-config/operations/iaas-worker.yml
-      - concourse-config/operations/postgres-staging.yml
-      - concourse-config/operations/driver.yml
-      - concourse-config/operations/config.yml
-      - concourse-config/operations/generic-oauth.yml
-      - concourse-config/operations/compliance.yml
-      - concourse-config/operations/external-postgres-tls.yml
-      - concourse-config/operations/prometheus.yml
-      - concourse-config/operations/set-garbage-collection.yml
-      - concourse-config/operations/base-resource-defaults.yml
-      - concourse-config/operations/max-containers.yml
-      - concourse-config/operations/bosh-dns-aliases.yml
-      - concourse-config/operations/enable-across-step.yml
-      - concourse-config/operations/container-placement.yml
-      - concourse-config/operations/iptables.yml
-      - concourse-config/operations/redact-secrets.yml
-      vars_files:
-      - concourse-deployment/versions.yml
-      - concourse-config/variables/staging.yml
-      - concourse-config/variables/postgres-tls.yml
-      - terraform-yaml/state.yml
-  - task: smoke-test
-    file: concourse-config/ci/smoke-test.yml
-    params:
-      ATC_URL: https://ci.fr-stage.cloud.gov
-      BASIC_AUTH_USERNAME: ((basic-auth-username-staging))
-      BASIC_AUTH_PASSWORD: ((basic-auth-password-staging))
-  on_failure:
-    put: slack
-    params:
-      text: |
-        :x: FAILED to deploy Concourse on staging
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: '#cg-platform-news'
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-  on_success:
-    put: slack
-    params:
-      text: |
-        :white_check_mark: Successfully deployed Concourse on staging
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: '#cg-platform-news'
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-
-- name: iptables-staging
-  serial: true
-  interruptible: true
-  plan:
-  - task: iptables-iaas-worker-bosh-dns
-    config: &iptables-iaas-worker-bosh-dns
-      container_limits: {}
-      platform: linux
-      image_resource:
-        type: registry-image
-        source:
-          aws_access_key_id: ((ecr_aws_key))
-          aws_secret_access_key: ((ecr_aws_secret))
-          repository: general-task
-          aws_region: us-gov-west-1
-          tag: latest
+  - name: deploy-concourse-staging
+    serial: true
+    interruptible: true
+    plan:
+      - in_parallel:
+          - get: concourse-deployment
+            trigger: true
+          - get: concourse-config
+            trigger: true
+          - get: terraform-yaml
+          - get: concourse-stemcell-jammy
+            trigger: true
+      - put: concourse-staging-deployment
+        params: &deploy-params
+          manifest: concourse-deployment/cluster/concourse.yml
+          stemcells:
+            - concourse-stemcell-jammy/*.tgz
+          ops_files:
+            - concourse-deployment/cluster/operations/basic-auth.yml
+            - concourse-deployment/cluster/operations/build-log-retention.yml
+            - concourse-deployment/cluster/operations/scale.yml
+            - concourse-deployment/cluster/operations/enable-global-resources.yml
+            - concourse-config/operations/credhub.yml
+            - concourse-config/operations/iaas-worker.yml
+            - concourse-config/operations/postgres-staging.yml
+            - concourse-config/operations/driver.yml
+            - concourse-config/operations/config.yml
+            - concourse-config/operations/generic-oauth.yml
+            - concourse-config/operations/compliance.yml
+            - concourse-config/operations/external-postgres-tls.yml
+            - concourse-config/operations/prometheus.yml
+            - concourse-config/operations/set-garbage-collection.yml
+            - concourse-config/operations/base-resource-defaults.yml
+            - concourse-config/operations/max-containers.yml
+            - concourse-config/operations/bosh-dns-aliases.yml
+            - concourse-config/operations/enable-across-step.yml
+            - concourse-config/operations/container-placement.yml
+            - concourse-config/operations/iptables.yml
+            - concourse-config/operations/redact-secrets.yml
+          vars_files:
+            - concourse-deployment/versions.yml
+            - concourse-config/variables/staging.yml
+            - concourse-config/variables/postgres-tls.yml
+            - terraform-yaml/state.yml
+      - task: smoke-test
+        file: concourse-config/ci/smoke-test.yml
+        params:
+          ATC_URL: https://ci.fr-stage.cloud.gov
+          BASIC_AUTH_USERNAME: ((basic-auth-username-staging))
+          BASIC_AUTH_PASSWORD: ((basic-auth-password-staging))
+    on_failure:
+      put: slack
       params:
-        BOSH_ENVIRONMENT: ((concourse-staging-deployment-bosh-target))
-        BOSH_CLIENT: ci
-        BOSH_CLIENT_SECRET: ((tooling_bosh_uaa_ci_client_secret))
-        BOSH_CA_CERT: ((common_ca_cert_store))
-        BOSH_DEPLOYMENT: concourse-staging
-      run:
-        path: sh
-        args:
-        - -exc
-        - |
-          bosh ssh iaas-worker "sudo sh -c 'iptables-legacy -D INPUT -s 10.80.0.0/16 -d 169.254.0.2/32 -p udp -m udp --dport 53 -j ACCEPT || true'"
-          bosh ssh iaas-worker "sudo sh -c 'iptables-legacy -D INPUT -s 10.80.0.0/16 -d 169.254.0.2/32 -p tcp -m tcp --dport 53 -j ACCEPT || true'"
-          bosh ssh iaas-worker "sudo sh -c 'iptables-legacy -I INPUT 1 -s 10.80.0.0/16 -d 169.254.0.2/32 -p udp -m udp --dport 53 -j ACCEPT'"
-          bosh ssh iaas-worker "sudo sh -c 'iptables-legacy -I INPUT 1 -s 10.80.0.0/16 -d 169.254.0.2/32 -p tcp -m tcp --dport 53 -j ACCEPT'"
-          bosh ssh iaas-worker "sudo sh -c '/var/vcap/jobs/aide/bin/update-aide-db'"
-
-  - task: iptables-worker-bosh-dns
-    tags: [iaas]
-    config: &iptables-worker-bosh-dns
-      container_limits: {}
-      platform: linux
-      image_resource:
-        type: registry-image
-        source:
-          aws_access_key_id: ((ecr_aws_key))
-          aws_secret_access_key: ((ecr_aws_secret))
-          repository: general-task
-          aws_region: us-gov-west-1
-          tag: latest
+        text: |
+          :x: FAILED to deploy Concourse on staging
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: "#cg-platform-news"
+        username: ((slack-username))
+        icon_url: ((slack-icon-url))
+    on_success:
+      put: slack
       params:
-        BOSH_ENVIRONMENT: ((concourse-staging-deployment-bosh-target))
-        BOSH_CLIENT: ci
-        BOSH_CLIENT_SECRET: ((tooling_bosh_uaa_ci_client_secret))
-        BOSH_CA_CERT: ((common_ca_cert_store))
-        BOSH_DEPLOYMENT: concourse-staging
-      run:
-        path: sh
-        args:
-        - -exc
-        - |
-          bosh ssh worker "sudo sh -c 'iptables-legacy -D INPUT -s 10.80.0.0/16 -d 169.254.0.2/32 -p udp -m udp --dport 53 -j ACCEPT || true'"
-          bosh ssh worker "sudo sh -c 'iptables-legacy -D INPUT -s 10.80.0.0/16 -d 169.254.0.2/32 -p tcp -m tcp --dport 53 -j ACCEPT || true'"
-          bosh ssh worker "sudo sh -c 'iptables-legacy -I INPUT 1 -s 10.80.0.0/16 -d 169.254.0.2/32 -p udp -m udp --dport 53 -j ACCEPT'"
-          bosh ssh worker "sudo sh -c 'iptables-legacy -I INPUT 1 -s 10.80.0.0/16 -d 169.254.0.2/32 -p tcp -m tcp --dport 53 -j ACCEPT'"
-          bosh ssh worker "sudo sh -c '/var/vcap/jobs/aide/bin/update-aide-db'"
+        text: |
+          :white_check_mark: Successfully deployed Concourse on staging
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: "#cg-platform-news"
+        username: ((slack-username))
+        icon_url: ((slack-icon-url))
 
-- name: deploy-concourse-production
-  serial: true
-  interruptible: true
-  plan:
-  - in_parallel:
-    - get: concourse-deployment
-      passed: [deploy-concourse-staging]
-    - get: concourse-config
-      passed: [deploy-concourse-staging]
-    - get: terraform-yaml
-    - get: concourse-stemcell-jammy
-      passed: [deploy-concourse-staging]
-  - put: concourse-production-deployment
-    params:
-      <<: *deploy-params
-      ops_files:
-      - concourse-deployment/cluster/operations/basic-auth.yml
-      - concourse-deployment/cluster/operations/build-log-retention.yml
-      - concourse-deployment/cluster/operations/scale.yml
-      - concourse-deployment/cluster/operations/enable-global-resources.yml
-      - concourse-config/operations/credhub.yml
-      - concourse-config/operations/iaas-worker.yml
-      - concourse-config/operations/postgres-production.yml
-      - concourse-config/operations/external-postgres-tls.yml
-      - concourse-config/operations/driver.yml
-      - concourse-config/operations/config.yml
-      - concourse-config/operations/generic-oauth.yml
-      - concourse-config/operations/compliance.yml
-      - concourse-config/operations/prometheus.yml
-      - concourse-config/operations/set-garbage-collection.yml
-      - concourse-config/operations/base-resource-defaults.yml
-      - concourse-config/operations/max-containers.yml
-      - concourse-config/operations/bosh-dns-aliases.yml
-      - concourse-config/operations/enable-across-step.yml
-      - concourse-config/operations/container-placement.yml
-      - concourse-config/operations/iptables.yml
-      - concourse-config/operations/redact-secrets.yml
-      vars_files:
-      - concourse-deployment/versions.yml
-      - concourse-config/variables/production.yml
-      - concourse-config/variables/postgres-tls.yml
-      - terraform-yaml/state.yml
-  on_failure:
-    put: slack
-    params:
-      text: |
-        :x: FAILED to deploy Concourse on production
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: '#cg-platform'
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
-  on_success:
-    put: slack
-    params:
-      text: |
-        :white_check_mark: Successfully deployed Concourse on production
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: '#cg-platform-news'
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
+  - name: iptables-staging
+    serial: true
+    interruptible: true
+    plan:
+      - task: iptables-iaas-worker-bosh-dns
+        config: &iptables-iaas-worker-bosh-dns
+          container_limits: {}
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              aws_access_key_id: ((ecr_aws_key))
+              aws_secret_access_key: ((ecr_aws_secret))
+              repository: general-task
+              aws_region: us-gov-west-1
+              tag: latest
+          params:
+            BOSH_ENVIRONMENT: ((concourse-staging-deployment-bosh-target))
+            BOSH_CLIENT: ci
+            BOSH_CLIENT_SECRET: ((tooling_bosh_uaa_ci_client_secret))
+            BOSH_CA_CERT: ((common_ca_cert_store))
+            BOSH_DEPLOYMENT: concourse-staging
+          run:
+            path: sh
+            args:
+              - -exc
+              - |
+                bosh ssh iaas-worker "sudo sh -c 'iptables-legacy -D INPUT -s 10.80.0.0/16 -d 169.254.0.2/32 -p udp -m udp --dport 53 -j ACCEPT || true'"
+                bosh ssh iaas-worker "sudo sh -c 'iptables-legacy -D INPUT -s 10.80.0.0/16 -d 169.254.0.2/32 -p tcp -m tcp --dport 53 -j ACCEPT || true'"
+                bosh ssh iaas-worker "sudo sh -c 'iptables-legacy -I INPUT 1 -s 10.80.0.0/16 -d 169.254.0.2/32 -p udp -m udp --dport 53 -j ACCEPT'"
+                bosh ssh iaas-worker "sudo sh -c 'iptables-legacy -I INPUT 1 -s 10.80.0.0/16 -d 169.254.0.2/32 -p tcp -m tcp --dport 53 -j ACCEPT'"
+                bosh ssh iaas-worker "sudo sh -c '/var/vcap/jobs/aide/bin/update-aide-db'"
 
-# by having a different job for iptables, we should work around the issue
-# where the concourse deployment seems to fail because we lose our worker
-# so the iptables job never runs and dns breaks until we re-run the whole
-# deployment job. By getting the production deployment we can be somewhat
-# sure that we'll notice the deployment finish asynchronously, then we'll
-# run these tasks before too long. There is a better solution - we should
-# really recover from the worker disappearing and resume tailing the task
-# logs - but that's a fix for another day
-- name: iptables-production
-  serial: true
-  interruptible: true
-  plan:
-  - task: iptables-iaas-worker-bosh-dns
-    config:
-      <<: *iptables-iaas-worker-bosh-dns
+      - task: iptables-worker-bosh-dns
+        tags: [iaas]
+        config: &iptables-worker-bosh-dns
+          container_limits: {}
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              aws_access_key_id: ((ecr_aws_key))
+              aws_secret_access_key: ((ecr_aws_secret))
+              repository: general-task
+              aws_region: us-gov-west-1
+              tag: latest
+          params:
+            BOSH_ENVIRONMENT: ((concourse-staging-deployment-bosh-target))
+            BOSH_CLIENT: ci
+            BOSH_CLIENT_SECRET: ((tooling_bosh_uaa_ci_client_secret))
+            BOSH_CA_CERT: ((common_ca_cert_store))
+            BOSH_DEPLOYMENT: concourse-staging
+          run:
+            path: sh
+            args:
+              - -exc
+              - |
+                bosh ssh worker "sudo sh -c 'iptables-legacy -D INPUT -s 10.80.0.0/16 -d 169.254.0.2/32 -p udp -m udp --dport 53 -j ACCEPT || true'"
+                bosh ssh worker "sudo sh -c 'iptables-legacy -D INPUT -s 10.80.0.0/16 -d 169.254.0.2/32 -p tcp -m tcp --dport 53 -j ACCEPT || true'"
+                bosh ssh worker "sudo sh -c 'iptables-legacy -I INPUT 1 -s 10.80.0.0/16 -d 169.254.0.2/32 -p udp -m udp --dport 53 -j ACCEPT'"
+                bosh ssh worker "sudo sh -c 'iptables-legacy -I INPUT 1 -s 10.80.0.0/16 -d 169.254.0.2/32 -p tcp -m tcp --dport 53 -j ACCEPT'"
+                bosh ssh worker "sudo sh -c '/var/vcap/jobs/aide/bin/update-aide-db'"
+
+  - name: deploy-concourse-production
+    serial: true
+    interruptible: true
+    plan:
+      - in_parallel:
+          - get: concourse-deployment
+            passed: [deploy-concourse-staging]
+          - get: concourse-config
+            passed: [deploy-concourse-staging]
+          - get: terraform-yaml
+          - get: concourse-stemcell-jammy
+            passed: [deploy-concourse-staging]
+      - put: concourse-production-deployment
+        params:
+          <<: *deploy-params
+          ops_files:
+            - concourse-deployment/cluster/operations/basic-auth.yml
+            - concourse-deployment/cluster/operations/build-log-retention.yml
+            - concourse-deployment/cluster/operations/scale.yml
+            - concourse-deployment/cluster/operations/enable-global-resources.yml
+            - concourse-config/operations/credhub.yml
+            - concourse-config/operations/iaas-worker.yml
+            - concourse-config/operations/postgres-production.yml
+            - concourse-config/operations/external-postgres-tls.yml
+            - concourse-config/operations/driver.yml
+            - concourse-config/operations/config.yml
+            - concourse-config/operations/generic-oauth.yml
+            - concourse-config/operations/compliance.yml
+            - concourse-config/operations/prometheus.yml
+            - concourse-config/operations/set-garbage-collection.yml
+            - concourse-config/operations/base-resource-defaults.yml
+            - concourse-config/operations/max-containers.yml
+            - concourse-config/operations/bosh-dns-aliases.yml
+            - concourse-config/operations/enable-across-step.yml
+            - concourse-config/operations/container-placement.yml
+            - concourse-config/operations/iptables.yml
+            - concourse-config/operations/redact-secrets.yml
+          vars_files:
+            - concourse-deployment/versions.yml
+            - concourse-config/variables/production.yml
+            - concourse-config/variables/postgres-tls.yml
+            - terraform-yaml/state.yml
+    on_failure:
+      put: slack
       params:
-        BOSH_ENVIRONMENT: ((concourse-production-deployment-bosh-target))
-        BOSH_CLIENT: ci
-        BOSH_CLIENT_SECRET: ((tooling_bosh_uaa_ci_client_secret))
-        BOSH_CA_CERT: ((common_ca_cert_store))
-        BOSH_DEPLOYMENT: concourse-production
-  - task: iptables-worker-bosh-dns
-    tags: [iaas]
-    config:
-      <<: *iptables-worker-bosh-dns
+        text: |
+          :x: FAILED to deploy Concourse on production
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: "#cg-platform"
+        username: ((slack-username))
+        icon_url: ((slack-icon-url))
+    on_success:
+      put: slack
       params:
-        BOSH_ENVIRONMENT: ((concourse-production-deployment-bosh-target))
-        BOSH_CLIENT: ci
-        BOSH_CLIENT_SECRET: ((tooling_bosh_uaa_ci_client_secret))
-        BOSH_CA_CERT: ((common_ca_cert_store))
-        BOSH_DEPLOYMENT: concourse-production
+        text: |
+          :white_check_mark: Successfully deployed Concourse on production
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: "#cg-platform-news"
+        username: ((slack-username))
+        icon_url: ((slack-icon-url))
+
+  # by having a different job for iptables, we should work around the issue
+  # where the concourse deployment seems to fail because we lose our worker
+  # so the iptables job never runs and dns breaks until we re-run the whole
+  # deployment job. By getting the production deployment we can be somewhat
+  # sure that we'll notice the deployment finish asynchronously, then we'll
+  # run these tasks before too long. There is a better solution - we should
+  # really recover from the worker disappearing and resume tailing the task
+  # logs - but that's a fix for another day
+  - name: iptables-production
+    serial: true
+    interruptible: true
+    plan:
+      - task: iptables-iaas-worker-bosh-dns
+        config:
+          <<: *iptables-iaas-worker-bosh-dns
+          params:
+            BOSH_ENVIRONMENT: ((concourse-production-deployment-bosh-target))
+            BOSH_CLIENT: ci
+            BOSH_CLIENT_SECRET: ((tooling_bosh_uaa_ci_client_secret))
+            BOSH_CA_CERT: ((common_ca_cert_store))
+            BOSH_DEPLOYMENT: concourse-production
+      - task: iptables-worker-bosh-dns
+        tags: [iaas]
+        config:
+          <<: *iptables-worker-bosh-dns
+          params:
+            BOSH_ENVIRONMENT: ((concourse-production-deployment-bosh-target))
+            BOSH_CLIENT: ci
+            BOSH_CLIENT_SECRET: ((tooling_bosh_uaa_ci_client_secret))
+            BOSH_CA_CERT: ((common_ca_cert_store))
+            BOSH_DEPLOYMENT: concourse-production
 
 resources:
-- name: concourse-deployment
-  type: git
-  source:
-    uri: https://github.com/concourse/concourse-bosh-deployment
-    branch: master
-    tag_filter: v7.*
+  - name: concourse-deployment
+    type: git
+    source:
+      uri: https://github.com/concourse/concourse-bosh-deployment
+      branch: master
+      tag_filter: v7.*
 
-- name: concourse-config
-  type: git
-  source:
-    commit_verification_keys: ((cloud-gov-pgp-keys))
-    branch: main
-    uri: ((concourse-config-git-url))
+  - name: concourse-config
+    type: git
+    source:
+      commit_verification_keys: ((cloud-gov-pgp-keys))
+      branch: main
+      uri: ((concourse-config-git-url))
 
-- name: concourse-stemcell-jammy
-  type: bosh-io-stemcell
-  source:
-    name: bosh-aws-xen-hvm-ubuntu-jammy-go_agent
+  - name: concourse-stemcell-jammy
+    type: bosh-io-stemcell
+    source:
+      name: bosh-aws-xen-hvm-ubuntu-jammy-go_agent
 
-- name: concourse-production-deployment
-  type: bosh-deployment
-  source:
-    target: ((concourse-production-deployment-bosh-target))
-    client: ci
-    client_secret: ((tooling_bosh_uaa_ci_client_secret))
-    deployment: ((concourse-production-deployment-bosh-deployment))
-    ca_cert: ((common_ca_cert_store))
+  - name: concourse-production-deployment
+    type: bosh-deployment
+    source:
+      target: ((concourse-production-deployment-bosh-target))
+      client: ci
+      client_secret: ((tooling_bosh_uaa_ci_client_secret))
+      deployment: ((concourse-production-deployment-bosh-deployment))
+      ca_cert: ((common_ca_cert_store))
 
-- name: concourse-staging-deployment
-  type: bosh-deployment
-  source:
-    target: ((concourse-staging-deployment-bosh-target))
-    client: ci
-    client_secret: ((tooling_bosh_uaa_ci_client_secret))
-    deployment: ((concourse-staging-deployment-bosh-deployment))
-    ca_cert: ((common_ca_cert_store))
+  - name: concourse-staging-deployment
+    type: bosh-deployment
+    source:
+      target: ((concourse-staging-deployment-bosh-target))
+      client: ci
+      client_secret: ((tooling_bosh_uaa_ci_client_secret))
+      deployment: ((concourse-staging-deployment-bosh-deployment))
+      ca_cert: ((common_ca_cert_store))
 
-- name: slack
-  type: slack-notification
-  source:
-    url: ((slack-webhook-url))
+  - name: slack
+    type: slack-notification
+    source:
+      url: ((slack-webhook-url))
 
-- name: terraform-yaml
-  type: s3-iam
-  source:
-    bucket: ((tf-state-bucket))
-    versioned_file: ((tf-state-file))
-    region_name: ((aws-region))
+  - name: terraform-yaml
+    type: s3-iam
+    source:
+      bucket: ((tf-state-bucket))
+      versioned_file: ((tf-state-file))
+      region_name: ((aws-region))
 
 resource_types:
-- name: registry-image
-  type: registry-image
-  source:
-    aws_access_key_id: ((ecr_aws_key))
-    aws_secret_access_key: ((ecr_aws_secret))
-    repository: registry-image-resource
-    aws_region: us-gov-west-1
-    tag: latest
+  - name: registry-image
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: registry-image-resource
+      aws_region: us-gov-west-1
+      tag: latest
 
-- name: slack-notification
-  type: registry-image
-  source:
-    aws_access_key_id: ((ecr_aws_key))
-    aws_secret_access_key: ((ecr_aws_secret))
-    repository: slack-notification-resource
-    aws_region: us-gov-west-1
-    tag: latest
+  - name: slack-notification
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: slack-notification-resource
+      aws_region: us-gov-west-1
+      tag: latest
 
-- name: bosh-deployment
-  type: registry-image
-  source:
-    aws_access_key_id: ((ecr_aws_key))
-    aws_secret_access_key: ((ecr_aws_secret))
-    repository: bosh-deployment-resource
-    aws_region: us-gov-west-1
-    tag: latest
+  - name: bosh-deployment
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: bosh-deployment-resource
+      aws_region: us-gov-west-1
+      tag: latest
 
-- name: s3-iam
-  type: registry-image
-  source:
-    aws_access_key_id: ((ecr_aws_key))
-    aws_secret_access_key: ((ecr_aws_secret))
-    repository: s3-resource
-    aws_region: us-gov-west-1
-    tag: latest
+  - name: s3-iam
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: s3-resource
+      aws_region: us-gov-west-1
+      tag: latest
 
-- name: git
-  type: registry-image
-  source:
-    aws_access_key_id: ((ecr_aws_key))
-    aws_secret_access_key: ((ecr_aws_secret))
-    repository: git-resource
-    aws_region: us-gov-west-1
-    tag: latest
+  - name: git
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: git-resource
+      aws_region: us-gov-west-1
+      tag: latest
 
-- name: bosh-io-stemcell
-  type: registry-image
-  source:
-    aws_access_key_id: ((ecr_aws_key))
-    aws_secret_access_key: ((ecr_aws_secret))
-    repository: bosh-io-stemcell-resource
-    aws_region: us-gov-west-1
-    tag: latest
+  - name: bosh-io-stemcell
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: bosh-io-stemcell-resource
+      aws_region: us-gov-west-1
+      tag: latest

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -12,6 +12,9 @@ jobs:
           - get: terraform-yaml
           - get: concourse-stemcell-jammy
             trigger: true
+          - put: stemcell-lock-pool
+            params:
+              claim: updating-stemcells
       - put: concourse-staging-deployment
         params: &deploy-params
           manifest: concourse-deployment/cluster/concourse.yml
@@ -50,15 +53,27 @@ jobs:
           ATC_URL: https://ci.fr-stage.cloud.gov
           BASIC_AUTH_USERNAME: ((basic-auth-username-staging))
           BASIC_AUTH_PASSWORD: ((basic-auth-password-staging))
-    on_failure:
-      put: slack
+    on_error:
+      put: stemcell-lock-pool
       params:
-        text: |
-          :x: FAILED to deploy Concourse on staging
-          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-        channel: "#cg-platform-news"
-        username: ((slack-username))
-        icon_url: ((slack-icon-url))
+        release: stemcell-lock-pool
+    on_abort:
+      put: stemcell-lock-pool
+      params:
+        release: stemcell-lock-pool
+    on_failure:
+      do:
+        - put: slack
+          params:
+            text: |
+              :x: FAILED to deploy Concourse on staging
+              <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+            channel: "#cg-platform-news"
+            username: ((slack-username))
+            icon_url: ((slack-icon-url))
+        - put: stemcell-lock-pool
+          params:
+            release: stemcell-lock-pool
     on_success:
       put: slack
       params:
@@ -192,6 +207,10 @@ jobs:
         channel: "#cg-platform-news"
         username: ((slack-username))
         icon_url: ((slack-icon-url))
+    ensure:
+      put: stemcell-lock-pool
+      params:
+        release: stemcell-lock-pool
 
   # by having a different job for iptables, we should work around the issue
   # where the concourse deployment seems to fail because we lose our worker
@@ -275,6 +294,20 @@ resources:
       versioned_file: ((tf-state-file))
       region_name: ((aws-region))
 
+  - name: stemcell-lock-pool
+    type: pool
+    source:
+      uri: git@github.com:cloud-gov/concourse-locks.git
+      branch: concourse # main is protected, so use a topic branch
+      pool: stemcell
+      username: cg-ci-bot
+      private_key: ((cg-ci-bot-sshkey.private_key))
+      git_config:
+        - name: "user.name"
+          value: "cg-ci-bot"
+        - name: "user.email"
+          value: "no-reply@cloud.gov"
+
 resource_types:
   - name: registry-image
     type: registry-image
@@ -327,5 +360,14 @@ resource_types:
       aws_access_key_id: ((ecr_aws_key))
       aws_secret_access_key: ((ecr_aws_secret))
       repository: bosh-io-stemcell-resource
+      aws_region: us-gov-west-1
+      tag: latest
+
+  - name: pool
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: pool-resource
       aws_region: us-gov-west-1
       tag: latest


### PR DESCRIPTION
## Changes proposed in this pull request:
- The pipeline must acquire the lock to start, and it will release on the lock on job failure or pipeline success
- Related to https://github.com/cloud-gov/product/issues/3130
- Related to https://github.com/cloud-gov/cg-deploy-bosh/pull/620

## security considerations
Credentials to the git user with write access are protected using standard practices. 